### PR TITLE
Improve keyboard focus styles

### DIFF
--- a/object-values-entries.js
+++ b/object-values-entries.js
@@ -1,0 +1,3 @@
+// https://github.com/tc39/proposal-object-values-entries
+require('../modules/es.object.entries');
+require('../modules/es.object.values');


### PR DESCRIPTION
Enhance keyboard focus visibility for accessibility by replacing faint outlines with a high-contrast 3px ring on buttons and links. Use :focus-visible to limit the effect to keyboard interactions and update variables so the change is theme-safe.